### PR TITLE
Enable GitHub auto-generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v2
         with:
+          generate_release_notes: true
           files: |
             build/cordon-darwin-arm64
             build/cordon-darwin-amd64


### PR DESCRIPTION
## Summary
Enable GitHub-generated release notes in the release workflow by setting `generate_release_notes: true` on `softprops/action-gh-release@v2`.

## Why
This uses GitHub's built-in comparison against previous tags/releases to build release notes automatically while keeping the existing artifact upload flow unchanged.
